### PR TITLE
fix package name in ffmpeg_vad_streaming example

### DIFF
--- a/ffmpeg_vad_streaming/package.json
+++ b/ffmpeg_vad_streaming/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "argparse": "^1.0.10",
-    "STT": "^1.0.0",
+    "stt": "^1.0.0",
     "node-vad": "^1.1.1",
     "util": "^0.11.1"
   },


### PR DESCRIPTION
```
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/STT - Not found
npm ERR! 404
npm ERR! 404  'STT@^1.0.0' is not in this registry.
npm ERR! 404 This package name is not valid, because
npm ERR! 404  1. name can no longer contain capital letters
```