### PR TITLE
Add a simple WASM example

### DIFF
--- a/wasm/README.md
+++ b/wasm/README.md
@@ -1,0 +1,35 @@
+# STT WebAssembly example
+
+This is an example of STT running in a web page and processing audio files.
+
+## Install
+
+Install NPM modules (only used to serve the web page):
+
+```
+npm install
+```
+
+Download the latest version of the STT library:
+
+```
+npm run download
+```
+
+(Optional) Download a pre-trained model and scorer from the [Coqui Model Zoo](https://coqui.ai/models) to the root of the project:
+
+```
+mkdir models
+cd models
+mv $HOME/Downloads/model.tflite .
+mv $HOME/Downloads/huge-vocab.scorer .
+cd ..
+```
+
+## Run
+
+Serve the demo:
+
+```
+npm run start
+```

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>WASM Sample</title>
+  </head>
+  <body>
+    <script src="lib/stt_wasm.js"></script>
+    <script>
+        var activeModel;
+        var audioContext;
+        var stt;
+
+        // https://stackoverflow.com/q/33738873/261698
+        function converFloat32ToInt16(buffer) {
+            return Int16Array.from(buffer, x => x * 32767);
+        }
+
+        function loadModel(modelFiles) {
+            console.log(`Loading models`, modelFiles);
+
+            let reader = new FileReader();
+            reader.onload = (e) => {
+                activeModel = new stt.Model(new Uint8Array(reader.result));
+                const modelSampleRate = activeModel.getSampleRate();
+                console.log(`Model sample rate: ${modelSampleRate}`);
+
+                // Create an audio context for future processing.
+                audioContext = new AudioContext({
+                    // Use the model's sample rate so that the decoder will resample for us.
+                    sampleRate: modelSampleRate
+                });
+
+                const scorerInput = document.getElementById("scorerpicker");
+                scorerInput.addEventListener("change", (e) => loadScorer(e.target.files[0]), false);
+                scorerInput.disabled = false;
+
+                // Now that a model is available, enable opening the audio file.
+                const audioInput = document.getElementById("audiopicker");
+                audioInput.addEventListener("change", (e) => processAudio(e.target.files[0]), false);
+                audioInput.disabled = false;
+            };
+            reader.readAsArrayBuffer(modelFiles[0]);
+        };
+
+        function loadScorer(scorerFile) {
+            console.log(`Loading scorer`, scorerFile);
+
+            const reader = new FileReader();
+            reader.onload = (e) => {
+                activeModel.enableExternalScorer(new Uint8Array(reader.result));
+                console.log("Scorer loaded");
+            };
+            reader.readAsArrayBuffer(scorerFile);
+        };
+
+        function processAudio(audioFile) {
+            console.log(`Loading audio file`, audioFile);
+
+            let reader = new FileReader();
+            reader.onload = (e) => {
+                audioContext.decodeAudioData(reader.result).then(decodedAudio => {
+                    const processedAudio = converFloat32ToInt16(decodedAudio.getChannelData(0));
+
+                    // Convert the `processedAudio` to something that can be passed
+                    // across the WASM boundaries.
+                    const toPass = new stt.VectorShort();
+                    processedAudio.forEach(e => toPass.push_back(e));
+
+                    const now = Date.now();
+                    const result = activeModel.speechToText(toPass);
+                    const elapsedSeconds = (Date.now() - now)/1000;
+
+                    document.getElementById("result").textContent = result;
+                    console.log(`Transcription: ${result}`);
+
+                    document.getElementById("elapsedSeconds").textContent = elapsedSeconds;
+                    console.log(`Elapsed: ${elapsedSeconds} seconds`)
+                });
+            };
+            reader.readAsArrayBuffer(audioFile);
+        };
+
+        STT().then(module => {
+            stt = module;
+
+            // Now that we know the WASM module is ready, enable
+            // the file picker for the model.
+            const input = document.getElementById("modelpicker");
+            input.addEventListener("change", (e) => loadModel(e.target.files), false);
+            input.disabled = false;
+        });
+    </script>
+    <div>
+        <label for="modelpicker">Coqui TFLite Model file:</label>
+        <input type="file" name="modelpicker" id="modelpicker" disabled>
+
+        <br />
+
+        <label for="scorerpicker">Scorer (optional):</label>
+        <input type="file" name="scorerpicker" id="scorerpicker" disabled>
+
+        <br />
+
+        <label for="audiopicker">Audio sample file:</label>
+        <input type="file" name="audiopicker" id="audiopicker" disabled>
+
+        <br />
+
+        <label for="result">Transcription:</label>
+        <span id="result"></span>
+
+        <br />
+
+        <label for="elapsedSeconds">Elapsed time (s):</label>
+        <span id="elapsedSeconds"></span>
+    </div>
+  </body>
+</html>

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "wasm_simple",
+  "version": "0.1.0",
+  "description": "A simple STT WASM example that loads an audio file and processes it",
+  "private": true,
+  "scripts": {
+    "download": "download --extract --strip 1 --out lib https://github.com/coqui-ai/STT/releases/latest/download/libstt.tflite.wasm.zip",
+    "start": "ws --cors.opener-policy same-origin --cors.embedder-policy require-corp"
+  },
+  "dependencies": {
+    "download-cli": "^1.1.1",
+    "local-web-server": "^5.2.1"
+  }
+}


### PR DESCRIPTION
This is a simple demo for the WASM version of STT, which does not require a bundler and fetches the WASM libstt directly from the latest Github release.

NPM is used to reduce the boilerplate by reusing an HTTP server and a file downloader\unzipper.

**Note**: `npm download` currently fails as the "1.4.0" is marked as pre-release. 

# Pull request guidelines

Welcome to the 🐸STT-examples project! We are excited to see your interest, and we appreciate your support!

This repository is governed by the Contributor Covenant Code of Conduct. For more details, see the [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) file.

Before accepting your pull request, you will be asked to sign a [Contributor License Agreement](https://cla-assistant.io/coqui-ai/STT-examples).

This [Contributor License Agreement](https://cla-assistant.io/coqui-ai/STT-examples):

- Protects you, Coqui, and the users of the code.
- Does not change your rights to use your contributions for any purpose.
- Does not change the license of the 🐸STT-examples project. It just makes the terms of your contribution clearer and lets us know you are OK to contribute.
